### PR TITLE
Add Nextcloud to File Sharing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,8 @@ Keep notes during meetings, and keep files organized and shareable.
 ### File Sharing
 - [Dropbox](https://www.dropbox.com) - Dropbox is a modern workspace designed to reduce busywork – so you can focus on the things that matter.
 - [Google Drive](https://www.google.com/drive/) - Cloud Storage & File Backup for Photos, Docs & More
-- [Owncloud](https://owncloud.org/) - ownCloud is the largest Open Source Content Collaboration Platform in the world
+- [Nextcloud](https://nextcloud.com/) - Open source cloud and collaboration platform based on ownCloud
+- [ownCloud](https://owncloud.org/) - ownCloud is the largest Open Source Content Collaboration Platform in the world
 
 ### Bibliography Management
 - [Zotero](https://www.zotero.org/) - Your personal


### PR DESCRIPTION
Nextcloud is a fork of ownCloud which seems to be more active lately, so it makes sense to add it to the list.

This pull request also uses the official capitalization of ownCloud consistently.